### PR TITLE
[SON-387] Refactor serf connection to automatically close on error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serf-rpc"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ben Aubin <ben@benaubin.com>"]
 edition = "2018"
 repository = "https://github.com/benaubin/serf-rs"
@@ -16,5 +16,4 @@ futures = {version="0.3.12"}
 rmp = "0.8.10"
 serde_bytes = "0.11.5"
 log = "0.4"
-[dev-dependencies]
 tokio = { version = "1.2.0", features=["full"] }

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use log::{Level, Metadata, Record};
 use log::{LevelFilter, SetLoggerError};
-const SERF_ADDRESS: &'static str = "0.0.0.0";
-const SERF_PORT: &'static str = ":7373";
+const SERF_ADDRESS: &str = "0.0.0.0";
+const SERF_PORT: &str = ":7373";
 
 struct SimpleLogger;
 

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -1,4 +1,4 @@
-use futures::{StreamExt};
+use futures::StreamExt;
 
 use std::sync::Arc;
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,0 +1,180 @@
+use std::{
+    net::{SocketAddr, TcpStream},
+    sync::{atomic::AtomicBool, mpsc::Receiver},
+    thread::JoinHandle,
+};
+
+use std::io;
+use std::sync::{Arc, Mutex};
+
+use io::{BufReader, Write};
+use log::{error, info};
+
+pub use crate::request::RPCRequest;
+pub use crate::stream::RPCStream;
+use crate::{DispatchMap, SeqRead};
+use tokio::sync::Notify;
+
+pub(crate) struct ClientConnection {
+    notifier: Arc<Notify>,
+    cancel: Arc<AtomicBool>,
+    dispatch: Arc<Mutex<DispatchMap>>,
+    stream: TcpStream,
+}
+
+impl ClientConnection {
+    fn start_serf_tx(
+        &mut self,
+        rx_rw: std::sync::mpsc::Receiver<Vec<u8>>,
+    ) -> Result<JoinHandle<()>, String> {
+        let notifier = Arc::clone(&self.notifier);
+        let cancel = Arc::clone(&self.cancel);
+        let mut stream = self.stream.try_clone().map_err(|x| x.to_string())?;
+        Ok(std::thread::spawn(move || loop {
+            match rx_rw.recv() {
+                Ok(x) => {
+                    if let Err(e) = stream.write_all(&x) {
+                        error!("Error while writing to serf stream: {e}");
+                        cancel.store(true, std::sync::atomic::Ordering::Relaxed);
+                        notifier.notify_one();
+                        return;
+                    }
+                }
+                Err(e) => {
+                    error!("Error while receiving value from channel: {e}");
+                    cancel.store(true, std::sync::atomic::Ordering::Relaxed);
+                    notifier.notify_one();
+                    return;
+                }
+            }
+        }))
+    }
+
+    fn start_serf_rx(&mut self) -> Result<JoinHandle<()>, String> {
+        let notifier = Arc::clone(&self.notifier);
+        let cancel = Arc::clone(&self.cancel);
+        let dispatch = Arc::clone(&self.dispatch);
+        let mut reader = BufReader::new(self.stream.try_clone().map_err(|x| x.to_string())?);
+        Ok(std::thread::spawn(move || {
+            loop {
+                let crate::protocol::ResponseHeader { seq, error } =
+                    match rmp_serde::from_read(&mut reader) {
+                        Ok(x) => x,
+                        Err(e) => {
+                            error!("Error while reading messagepack: {e}");
+                            cancel.store(true, std::sync::atomic::Ordering::Relaxed);
+                            notifier.notify_one();
+                            return;
+                        }
+                    };
+
+                let seq_handler = {
+                    let mut dispatch = dispatch.lock().unwrap();
+                    match dispatch.map.get(&seq) {
+                        Some(v) => {
+                            if v.streaming() {
+                                if !v.stream_acked() {
+                                    continue;
+                                }
+                                v.clone()
+                            } else {
+                                dispatch.map.remove(&seq).unwrap()
+                            }
+                        }
+                        None => {
+                            // response with no handler, ignore
+                            continue;
+                        }
+                    }
+                };
+
+                let res = if error.is_empty() {
+                    Ok(SeqRead(&mut reader))
+                } else {
+                    Err(error)
+                };
+
+                seq_handler.handle(res);
+            }
+        }))
+    }
+
+    #[tokio::main(flavor = "current_thread")]
+    async fn connection_watcher(
+        dispatch: Arc<Mutex<DispatchMap>>,
+        cancel: Arc<AtomicBool>,
+        thread_notifier: Arc<Notify>,
+        stream: TcpStream,
+        serf_tx_handle: JoinHandle<()>,
+        serf_rx_handle: JoinHandle<()>,
+    ) {
+        while !cancel.load(std::sync::atomic::Ordering::Relaxed) {
+            info!("Waiting until connection threads send notification");
+            thread_notifier.notified().await;
+        }
+
+        info!("Cleaning up SERF threads");
+        drop(stream);
+
+        info!("Cleaning up existing SERF requests by responding with an error");
+        let mut lock = dispatch.lock().unwrap();
+        let map = &mut lock.map;
+        for (_, value) in map.iter() {
+            value.handle(Err(
+                "Request was cancelled due to an error in the SERF connection".to_string(),
+            ));
+        }
+        map.clear();
+        drop(lock);
+
+        if let Err(e) = serf_tx_handle.join() {
+            error!("Error in connection write thread: {e:?}");
+        }
+        if let Err(e) = serf_rx_handle.join() {
+            error!("Error in connection read thread: {e:?}");
+        }
+    }
+
+    fn start_connection_watcher(
+        &mut self,
+        serf_tx_handle: JoinHandle<()>,
+        serf_rx_handle: JoinHandle<()>,
+    ) -> Result<JoinHandle<()>, String> {
+        let notifier = Arc::clone(&self.notifier);
+        let cancel = Arc::clone(&self.cancel);
+        let dispatch = Arc::clone(&self.dispatch);
+        let stream = self.stream.try_clone().map_err(|x| x.to_string())?;
+        Ok(std::thread::spawn(move || {
+            Self::connection_watcher(
+                dispatch,
+                cancel,
+                notifier,
+                stream,
+                serf_tx_handle,
+                serf_rx_handle,
+            )
+        }))
+    }
+
+    pub(crate) fn spawn(
+        rpc_addr: SocketAddr,
+        serf_rx: Receiver<Vec<u8>>,
+        dispatch: Arc<Mutex<DispatchMap>>,
+    ) -> Result<Self, String> {
+        info!("Connecting to the Serf instance");
+        let stream = TcpStream::connect(rpc_addr).map_err(|e| e.to_string())?;
+        info!("Connected to the Serf instance");
+
+        let mut connection = Self {
+            notifier: Arc::new(Notify::new()),
+            cancel: Arc::new(AtomicBool::new(false)),
+            dispatch: Arc::clone(&dispatch),
+            stream,
+        };
+
+        let tx_handle = connection.start_serf_tx(serf_rx)?;
+        let rx_handle = connection.start_serf_rx()?;
+        connection.start_connection_watcher(tx_handle, rx_handle)?;
+        Ok(connection)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,9 +77,8 @@ impl Client {
     pub async fn connect(rpc_addr: SocketAddr, auth_key: Option<&str>) -> RPCResult<Self> {
         let (tx, rx) = std::sync::mpsc::channel();
         let dispatch = Arc::new(Mutex::new(DispatchMap::new()));
-        let dispatch_connection = Arc::clone(&dispatch);
 
-        ClientConnection::spawn(rpc_addr, rx, dispatch_connection)?;
+        ClientConnection::spawn(rpc_addr, rx, dispatch.clone())?;
         let client = Client { dispatch, tx };
         client.handshake(MAX_IPC_VERSION).await?;
         if let Some(auth_key) = auth_key {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,12 +7,13 @@ use std::{
 use std::io;
 use std::sync::{Arc, Mutex};
 
-use io::{BufReader, Write};
-use log::info;
+use connection::ClientConnection;
+use io::BufReader;
 use protocol::RequestHeader;
 use serde::de::DeserializeOwned;
 const MAX_IPC_VERSION: u32 = 1;
 
+mod connection;
 mod coordinates;
 mod members;
 mod request;
@@ -60,79 +61,27 @@ struct DispatchMap {
     next_seq: u64,
 }
 
+impl DispatchMap {
+    fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+            next_seq: 0,
+        }
+    }
+}
+
 impl Client {
     /// Connect to hub.
     ///
     /// Waits for handshake, and optionally for authentication if an auth key is provided.
     pub async fn connect(rpc_addr: SocketAddr, auth_key: Option<&str>) -> RPCResult<Self> {
         let (tx, rx) = std::sync::mpsc::channel();
+        let dispatch = Arc::new(Mutex::new(DispatchMap::new()));
+        let dispatch_connection = Arc::clone(&dispatch);
 
-        let dispatch = Arc::new(Mutex::new(DispatchMap {
-            map: HashMap::new(),
-            next_seq: 0,
-        }));
-
+        ClientConnection::spawn(rpc_addr, rx, dispatch_connection)?;
         let client = Client { dispatch, tx };
-
-        let dispatch = Arc::downgrade(&client.dispatch);
-
-        std::thread::spawn(move || {
-            let mut stream = {
-                info!("Connecting to the Serf instance");
-                loop {
-                    if let Ok(stream) = TcpStream::connect(rpc_addr) {
-                        info!("Connected to the Serf instance");
-                        break stream;
-                    }
-                }
-            };
-            // clone the stream to create a reader
-            let mut reader = BufReader::new(stream.try_clone().unwrap());
-
-            // write loop
-            std::thread::spawn(move || {
-                while let Ok(buf) = rx.recv() {
-                    stream.write_all(&buf).unwrap();
-                }
-            });
-
-            // read loop
-            while let Some(dispatch) = dispatch.upgrade() {
-                let protocol::ResponseHeader { seq, error } =
-                    rmp_serde::from_read(&mut reader).unwrap();
-
-                let seq_handler = {
-                    let mut dispatch = dispatch.lock().unwrap();
-                    match dispatch.map.get(&seq) {
-                        Some(v) => {
-                            if v.streaming() {
-                                if !v.stream_acked() {
-                                    continue;
-                                }
-                                v.clone()
-                            } else {
-                                dispatch.map.remove(&seq).unwrap()
-                            }
-                        }
-                        None => {
-                            // response with no handler, ignore
-                            continue;
-                        }
-                    }
-                };
-
-                let res = if error.is_empty() {
-                    Ok(SeqRead(&mut reader))
-                } else {
-                    Err(error)
-                };
-
-                seq_handler.handle(res);
-            }
-        });
-
         client.handshake(MAX_IPC_VERSION).await?;
-
         if let Some(auth_key) = auth_key {
             client.auth(auth_key).await?;
         }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -176,14 +176,16 @@ where
             let ipv6 = Ipv6Addr::from(ipv6);
             match ipv6.to_ipv4() {
                 None => Ok(ipv6.into()),
-                Some(ipv4) => Ok(ipv4.into())
+                Some(ipv4) => Ok(ipv4.into()),
             }
-        },
+        }
         Err(bytes) => {
             let maybe_ipv4: Result<[u8; 4], _> = bytes.try_into();
             match maybe_ipv4 {
                 Ok(ipv4) => Ok(ipv4.into()),
-                Err(bytes) => Err(D::Error::custom(format!("Could not parse {bytes:?} into IP address"))),
+                Err(bytes) => Err(D::Error::custom(format!(
+                    "Could not parse {bytes:?} into IP address"
+                ))),
             }
         }
     }


### PR DESCRIPTION
Previous version spawned two threads, one for reading and one for
writing. These threads would call unwrap which could lead to an
undefined state since the threads were never joined upon and the default
behaviour in rust is to only unwind a thread on panic. This commit adds
an additional thread that watches the read and write threads and on error
will close both and send errors through the dispatch handler.